### PR TITLE
Full functioning with ss api

### DIFF
--- a/xroad-metadata-proxy/api-client.go
+++ b/xroad-metadata-proxy/api-client.go
@@ -1,0 +1,46 @@
+package proxy
+
+import (
+  "time"
+  "net/http"
+  "crypto/tls"
+)
+
+type HTTPClient interface {
+  Do(req *http.Request) (*http.Response, error)
+}
+
+type MetadataServiceClient struct {
+  BaseURL    string
+  HTTPClient HTTPClient
+}
+
+type AdminAPIClient struct {
+  BaseURL    string
+  apiKey     string
+  HTTPClient HTTPClient
+}
+
+func NewMetadataServiceClient(config SSConfig) *MetadataServiceClient {
+  return &MetadataServiceClient{
+    BaseURL: config.URL,
+    HTTPClient: &http.Client{
+      Timeout: time.Minute,
+    },
+  }
+}
+
+func NewAdminAPIClient(config SSConfig) *AdminAPIClient {
+  return &AdminAPIClient{
+    BaseURL: config.AdminURL,
+    apiKey:  config.APIKey,
+    HTTPClient: &http.Client{
+      Timeout: time.Minute,
+      Transport: &http.Transport{
+        TLSClientConfig: &tls.Config{
+          InsecureSkipVerify: true,
+        },
+      },
+    },
+  }
+}

--- a/xroad-metadata-proxy/config.go
+++ b/xroad-metadata-proxy/config.go
@@ -8,21 +8,30 @@ import (
 )
 
 type Config struct {
-  Server       ServerConfig
-  Database     DatabaseConfig
+  Server          ServerConfig
+  Database        DatabaseConfig
+  SecurityServer  SSConfig
 }
 
 type ServerConfig struct {
-	Addr string
+  Addr string
 }
 
 type DatabaseConfig struct {
-	Addr string
+  Addr string
+}
+
+type SSConfig struct {
+  URL      string
+  AdminURL string
+  APIKey   string
 }
 
 func InitConfig() {
   viper.SetDefault("server.addr", "0.0.0.0:8083")
   viper.SetDefault("database.addr", "localhost:6379")
+  viper.SetDefault("securityserver.url", "http://localhost")
+  viper.SetDefault("securityserver.adminurl", "https://localhost:4000/api/v1")
 
   viper.SetConfigName("xroad-metadata-proxy")
   viper.AddConfigPath(".")
@@ -41,4 +50,7 @@ func InitConfig() {
   // Workaround because viper does not treat env vars the same as other config
   viper.BindEnv("database.addr")
   viper.BindEnv("server.addr")
+  viper.BindEnv("securityserver.url")
+  viper.BindEnv("securityserver.adminurl")
+  viper.BindEnv("securityserver.apikey")
 }

--- a/xroad-metadata-proxy/handler.go
+++ b/xroad-metadata-proxy/handler.go
@@ -45,6 +45,15 @@ func (sph *serviceProviderHandler) GetServiceProviders(w http.ResponseWriter, r 
   serviceCode := queries.Get("service-code")
 
   clientPathID := r.Header.Get("X-Road-Client")
+
+  if len(clientPathID) == 0 {
+    log.
+      WithField("X-Road-Client", clientPathID).
+      Error("Invalid X-Road-Client")
+
+    respondWithError(w, http.StatusBadRequest, "Invalid X-Road-Client " + clientPathID)
+    return
+  }
   clientID := strings.ReplaceAll(clientPathID, "/", ":")
 
   providers, err := sph.sps.FindServiceProviders(clientID, serviceCode)

--- a/xroad-metadata-proxy/handler.go
+++ b/xroad-metadata-proxy/handler.go
@@ -9,15 +9,6 @@ import (
   "github.com/gorilla/mux"
 )
 
-// For unit test, service interfaces
-type ServiceProviderService interface {
-	FindServiceProviders(serviceClientID string, serviceCode string) ([]*XRoadMember, error)
-}
-
-type ServiceClientService interface {
-	GetServiceClientsByService(serviceID string) ([]*XRoadMember, error)
-}
-
 type ServiceProviderHandler interface {
   GetServiceProviders(w http.ResponseWriter, r *http.Request)
 }

--- a/xroad-metadata-proxy/handler_test.go
+++ b/xroad-metadata-proxy/handler_test.go
@@ -5,71 +5,95 @@ import (
   "net/http/httptest"
   "testing"
   "encoding/json"
+  "fmt"
 
   "github.com/stretchr/testify/mock"
   "github.com/stretchr/testify/assert"
+  "github.com/gorilla/mux"
 )
 
-type MockProviderService struct {
+type mockServiceProviderService struct {
   mock.Mock
 }
 
-type MockClientService struct {
+type mockServiceClientService struct {
   mock.Mock
 }
 
-func (m *MockProviderService) GetAll() ([]*XRoadMember, error) {
-  args := m.Called()
+func (m *mockServiceProviderService) FindServiceProviders(serviceClientID string, serviceCode string) ([]*XRoadMember, error) {
+  args := m.Called(serviceClientID, serviceCode)
   return args.Get(0).([]*XRoadMember), args.Error(1)
 }
 
-func (m *MockClientService) GetAll() ([]*XRoadMember, error) {
-  args := m.Called()
+func (m *mockServiceClientService) GetServiceClientsByService(serviceID string) ([]*XRoadMember, error) {
+  args := m.Called(serviceID)
   return args.Get(0).([]*XRoadMember), args.Error(1)
 }
 
 func TestGetServiceProviders(t *testing.T) {
   var actualProviders []*XRoadMember
+  // TODO: Move it to test helpers
   expectedProviders := []*XRoadMember{
     &XRoadMember{ID: "CS:ORG:1111:Company1Provider", Name: "Company 1"},
     &XRoadMember{ID: "CS:ORG:1112:Company2Provider", Name: "Company 2"},
   }
 
-  mockProviderService := new(MockProviderService)
-  mockProviderService.On("GetAll").Return(expectedProviders, nil)
+  serviceCode := "TestService"
+  clientPathID := "CS/ORG/1111/Company1Subsystem"
+  clientID := "CS:ORG:1111:Company1Subsystem"
 
-  ph := NewProviderHandler(mockProviderService)
+  mocksps := new(mockServiceProviderService)
+  mocksps.
+    On("FindServiceProviders", clientID, serviceCode).
+    Return(expectedProviders, nil)
 
-  req := httptest.NewRequest("GET", "/service-providers", nil)
+  sph := NewServiceProviderHandler(mocksps)
+
+  path := fmt.Sprintf("/service-providers?service-code=%s", serviceCode)
+  req := httptest.NewRequest(http.MethodGet, path, nil)
+
+  req.Header.Set("X-Road-Client", clientPathID)
+
   w := httptest.NewRecorder()
 
-  http.HandlerFunc(ph.GetServiceProviders).ServeHTTP(w, req)
+  http.HandlerFunc(sph.GetServiceProviders).ServeHTTP(w, req)
 
   json.NewDecoder(w.Body).Decode(&actualProviders)
 
   assert.Equal(t, http.StatusOK, w.Code)
   assert.Equal(t, expectedProviders, actualProviders)
+  // TODO: Add more asserts
 }
 
-func TestGetServiceClients(t *testing.T) {
+func TestGetServiceServiceClients(t *testing.T) {
   var actualClients []*XRoadMember
+  // TODO: Move it to test helpers
   expectedClients := []*XRoadMember{
     &XRoadMember{ID: "CS:ORG:1111:Company1Provider", Name: "Company 1"},
     &XRoadMember{ID: "CS:ORG:1112:Company2Provider", Name: "Company 2"},
   }
 
-  mockClientService := new(MockClientService)
-  mockClientService.On("GetAll").Return(expectedClients, nil)
+  serviceID := "CS:ORG:1111:Company1Subsystem:TestService"
 
-  ph := NewClientHandler(mockClientService)
+  mockscs := new(mockServiceClientService)
+  mockscs.
+    On("GetServiceClientsByService", serviceID).
+    Return(expectedClients, nil)
 
-  req := httptest.NewRequest("GET", "/service-clients", nil)
+  sh := NewServiceHandler(mockscs)
+
+  path := fmt.Sprintf("/services/%s/service-clients", serviceID)
+  req := httptest.NewRequest(http.MethodGet, path, nil)
+
   w := httptest.NewRecorder()
 
-  http.HandlerFunc(ph.GetServiceClients).ServeHTTP(w, req)
+  router := mux.NewRouter()
+  router.HandleFunc("/services/{service-id}/service-clients", sh.GetServiceServiceClients)
+  router.ServeHTTP(w, req)
 
   json.NewDecoder(w.Body).Decode(&actualClients)
 
   assert.Equal(t, http.StatusOK, w.Code)
   assert.Equal(t, expectedClients, actualClients)
+  // TODO: Add more asserts
 }

--- a/xroad-metadata-proxy/models.go
+++ b/xroad-metadata-proxy/models.go
@@ -4,3 +4,7 @@ type XRoadMember struct {
   ID   string `json:"id"`
   Name string `json:"name"`
 }
+
+type Service struct {
+  ID   string `json:"id"`
+}

--- a/xroad-metadata-proxy/repository.go
+++ b/xroad-metadata-proxy/repository.go
@@ -2,196 +2,246 @@ package proxy
 
 import (
   "errors"
+  "strings"
+  "net/http"
+  "fmt"
+  "io/ioutil"
+  "encoding/json"
 
-  "github.com/go-redis/redis"
   log "github.com/sirupsen/logrus"
-  "github.com/mitchellh/mapstructure"
 )
 
-var providerKey = "providers"
-var clientKey = "clients"
-
-type XRoadMemberRepository interface {
-  GetAll() ([]*XRoadMember, error)
-  Set(xRoadMembers []*XRoadMember) error
+type ServiceProviderRepository interface {
+  GetAllServiceProviders() ([]*XRoadMember, error)
 }
 
-type ProviderRepository interface {
-  XRoadMemberRepository
+type ServiceRepository interface {
+  GetAllowedServices(serviceClientID string, serviceProvider *XRoadMember) ([]*Service, error)
 }
 
-type ClientRepository interface {
-  XRoadMemberRepository
+type ServiceClientRepository interface {
+  GetServiceClientsByService(serviceID string) ([]*XRoadMember, error)
 }
 
-type providerRepository struct {
-	client *redis.Client
+type serviceProviderRepository struct {
+  c *MetadataServiceClient
 }
 
-type clientRepository struct {
-	client *redis.Client
+type serviceRepository struct {
+  c *MetadataServiceClient
 }
 
-func NewProviderRepository(c *redis.Client) ProviderRepository {
-  return &providerRepository{c}
+type serviceClientRepository struct {
+  c *AdminAPIClient
 }
 
-func NewClientRepository(c *redis.Client) ClientRepository {
-  return &clientRepository{c}
+func NewServiceProviderRepository(c *MetadataServiceClient) ServiceProviderRepository {
+  return &serviceProviderRepository{c}
 }
 
-func (pr *providerRepository) GetAll() ([]*XRoadMember, error) {
-  match := providerKey + ":*"
+func NewServiceRepository(c *MetadataServiceClient) ServiceRepository {
+  return &serviceRepository{c}
+}
 
-  providers, err := getXRoadMembersByMatch(pr.client, match)
+func NewServiceClientRepository(c *AdminAPIClient) ServiceClientRepository {
+  return &serviceClientRepository{c}
+}
+
+func (spr *serviceProviderRepository) GetAllServiceProviders() ([]*XRoadMember, error) {
+  url := fmt.Sprintf("%s/listClients", spr.c.BaseURL)
+
+  req, err := http.NewRequest(http.MethodGet, url, nil)
   if err != nil {
-    return nil, errors.New("Failed to get X-Road member information")
+    log.
+      WithError(err).
+      Error("Failed to create http request")
+    return nil, err
   }
 
-  return providers, nil
-}
+  req.Header.Set("Accept", "application/json")
 
-func (pr *providerRepository) Set(xRoadMembers []*XRoadMember) error {
-  mapXRoadMembers, err := decodeStructs(xRoadMembers)
+  res, err := spr.c.HTTPClient.Do(req)
   if err != nil {
-    return err
+    log.
+      WithError(err).
+      Error("Failed to send")
+    return nil, err
   }
 
-  err = hMSetXRoadMembers(pr.client, mapXRoadMembers, providerKey)
+  body, err := ioutil.ReadAll(res.Body)
   if err != nil {
-    return err
+    log.
+      WithError(err).
+      Error("Failed to read")
+    return nil, err
   }
 
-  return nil
+  if res.StatusCode != 200 {
+    log.
+      WithFields(log.Fields{
+        "status_code": res.StatusCode,
+        "body":        string(body),
+      }).
+      Error("Failed to retrieve service providers from Metadata Service")
+
+    return nil, errors.New("Failed to retrieve service providers from Metadata Service")
+  }
+
+  var unmarshaledBody map[string]interface{}
+  err = json.Unmarshal(body, &unmarshaledBody)
+  if err != nil {
+    log.
+      WithError(err).
+      Error("Failed to unmarshal")
+    return nil, err
+  }
+
+  allProviders := make([]*XRoadMember, 0)
+  for _, member := range unmarshaledBody["member"].([]interface{}) {
+    id := member.(map[string]interface{})["id"].(map[string]interface{})
+
+    _, found := id["subsystem_code"].(string)
+    if !found {
+      continue
+    }
+
+    providerID := fmt.Sprintf(
+      "%s:%s:%s:%s",
+      id["xroad_instance"].(string),
+      id["member_class"].(string),
+      id["member_code"].(string),
+      id["subsystem_code"].(string),
+    )
+
+    xRoadMember := XRoadMember{}
+    xRoadMember.ID = providerID
+    xRoadMember.Name = member.(map[string]interface{})["name"].(string)
+
+    allProviders = append(allProviders, &xRoadMember)
+  }
+
+  return allProviders, nil
 }
 
-func (cr *clientRepository) GetAll() ([]*XRoadMember, error) {
-  match := clientKey + ":*"
+func (sr *serviceRepository) GetAllowedServices(serviceClientID string, serviceProvider *XRoadMember) ([]*Service, error) {
+  providerPathID := strings.ReplaceAll(serviceProvider.ID, ":", "/")
+  url := fmt.Sprintf("%s/r1/%s/allowedMethods", sr.c.BaseURL, providerPathID)
 
-  clients, err := getXRoadMembersByMatch(cr.client, match)
+  req, err := http.NewRequest(http.MethodGet, url, nil)
   if err != nil {
-    return nil, errors.New("Failed to get X-Road member information")
+    log.
+      WithError(err).
+      Error("Failed to create http request")
+    return nil, err
+  }
+
+  clientPathID := strings.ReplaceAll(serviceClientID, ":", "/")
+  req.Header.Set("X-Road-Client", clientPathID)
+
+  res, err := sr.c.HTTPClient.Do(req)
+  if err != nil {
+    log.
+      WithError(err).
+      Error("Failed to send")
+    return nil, err
+  }
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    log.
+      WithError(err).
+      Error("Failed to read")
+    return nil, err
+  }
+
+  if res.StatusCode != 200 {
+    log.
+      WithFields(log.Fields{
+        "status_code": res.StatusCode,
+        "body":   string(body),
+      }).
+      Error("Failed to retrieve allowed services from Metadata Service")
+
+    return nil, errors.New("Failed to retrieve allowed services from Metadata Service")
+  }
+
+  var unmarshaledBody map[string]interface{}
+  err = json.Unmarshal(body, &unmarshaledBody)
+  if err != nil {
+    log.
+    WithError(err).
+    Error("Failed to unmarshal")
+    return nil, err
+  }
+
+  allowedServices := make([]*Service, 0)
+  for _, service := range unmarshaledBody["service"].([]interface{}) {
+    serviceID := fmt.Sprintf(
+      "%s:%s:%s:%s:%s",
+      service.(map[string]interface{})["xroad_instance"],
+      service.(map[string]interface{})["member_class"],
+      service.(map[string]interface{})["member_code"],
+      service.(map[string]interface{})["subsystem_code"],
+      service.(map[string]interface{})["service_code"],
+    )
+
+    service := Service{ID: serviceID}
+
+    allowedServices = append(allowedServices, &service)
+  }
+
+  return allowedServices, nil
+}
+
+func (scr *serviceClientRepository) GetServiceClientsByService(serviceID string) ([]*XRoadMember, error) {
+  url := fmt.Sprintf("%s/services/%s/service-clients", scr.c.BaseURL, serviceID)
+
+  req, err := http.NewRequest(http.MethodGet, url, nil)
+  if err != nil {
+    log.
+      WithError(err).
+      Error("Failed to create http request")
+    return nil, err
+  }
+
+  apiKey := fmt.Sprintf("X-Road-ApiKey token=%s", scr.c.apiKey)
+  req.Header.Set("Authorization", apiKey)
+
+  res, err := scr.c.HTTPClient.Do(req)
+  if err != nil {
+    log.
+      WithError(err).
+      Error("Failed to send")
+    return nil, err
+  }
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    log.
+      WithError(err).
+      Error("Failed to read")
+    return nil, err
+  }
+
+  if res.StatusCode != 200 {
+    log.
+      WithFields(log.Fields{
+        "status_code": res.StatusCode,
+        "body":        string(body),
+      }).
+      Error("Failed to retrieve service clients from Admin API")
+
+    return nil, errors.New("Failed to retrieve service clients from Admin API")
+  }
+
+  var clients []*XRoadMember
+  err = json.Unmarshal(body, &clients)
+  if err != nil {
+    log.
+      WithError(err).
+      Error("Failed to unmarshal")
+    return nil, err
   }
 
   return clients, nil
-}
-
-func (cr *clientRepository) Set(xRoadMembers []*XRoadMember) error {
-  mapXRoadMembers, err := decodeStructs(xRoadMembers)
-  if err != nil {
-    return err
-  }
-
-  err = hMSetXRoadMembers(cr.client, mapXRoadMembers, clientKey)
-  if err != nil {
-    return err
-  }
-
-  return nil
-}
-
-func getXRoadMembersByMatch(client *redis.Client, match string) ([]*XRoadMember, error) {
-  var (
-    cursor uint64
-    xRoadMembers = make([]*XRoadMember, 0)
-  )
-
-  for {
-    var keys []string
-    var err error
-    keys, cursor, err = client.Scan(cursor, match, 10).Result()
-    if err != nil {
-      log.
-        WithError(err).
-        WithField("match", match).
-        Error("Failed to scan keys")
-      return nil, err
-    }
-    for _, key := range keys {
-      keyType, err := client.Type(key).Result()
-      if err != nil {
-        log.
-          WithError(err).
-          WithField("key", key).
-          Error("Failed to check type")
-        return nil, err
-      }
-      if keyType == "hash" {
-        var xRoadMember XRoadMember
-
-        mapXRoadMember, err := client.HGetAll(key).Result()
-        if err != nil {
-          log.
-            WithError(err).
-            WithField("key", key).
-            Error("Failed to get all fields")
-          return nil, err
-        }
-
-        err = mapstructure.Decode(mapXRoadMember, &xRoadMember)
-        if err != nil {
-          log.
-            WithError(err).
-            WithFields(log.Fields{
-              "input":  mapXRoadMember,
-              "output": xRoadMember,
-            }).
-            Error("Failed to decode")
-          return nil, err
-        }
-
-        xRoadMembers = append(xRoadMembers, &xRoadMember)
-      }
-    }
-
-    if cursor == 0 {
-      break
-    }
-  }
-
-  return xRoadMembers, nil
-}
-
-func hMSetXRoadMembers(client *redis.Client, mapXRoadMembers []map[string]interface{}, key string) error {
-  for _, mapXRoadMember := range mapXRoadMembers {
-    key = key + ":" + mapXRoadMember["ID"].(string)
-
-    err := client.HMSet(key, mapXRoadMember).Err()
-    if err != nil {
-      log.
-        WithError(err).
-        WithFields(log.Fields{
-          "key":  key,
-          "values": mapXRoadMember,
-        }).
-        Error("Failed to set data")
-      return err
-    }
-  }
-
-  return nil
-}
-
-func decodeStructs(xRoadMembers []*XRoadMember) ([]map[string]interface{}, error) {
-  var mapXRoadMembers []map[string]interface{}
-
-  for _, xRoadMember := range xRoadMembers {
-    var mapXRoadMember map[string]interface{}
-
-    err := mapstructure.Decode(xRoadMember, &mapXRoadMember)
-    if err != nil {
-      log.
-        WithError(err).
-        WithFields(log.Fields{
-          "input":  xRoadMember,
-          "output": mapXRoadMember,
-        }).
-        Error("Failed to decode")
-      return nil, err
-    }
-
-    mapXRoadMembers = append(mapXRoadMembers, mapXRoadMember)
-  }
-
-  return mapXRoadMembers, nil
 }

--- a/xroad-metadata-proxy/repository_test.go
+++ b/xroad-metadata-proxy/repository_test.go
@@ -2,8 +2,12 @@ package proxy
 
 import (
   "testing"
+  "io/ioutil"
+  "bytes"
+  "net/http"
 
   "github.com/stretchr/testify/assert"
+  "github.com/stretchr/testify/mock"
 )
 
 var expectedMapXRoadMembers = []map[string]interface{}{
@@ -18,66 +22,138 @@ var expectedXRoadMembers = []*XRoadMember{
   {ID: "CS:ORG:1113:Company3Subsystem", Name: "Company 3"},
 }
 
-func TestProviderRepository_GetAll(t *testing.T) {
-  mockClient, miniredis := NewRedisMock(t)
-  defer miniredis.Close()
-
-  err := hMSetXRoadMembers(mockClient, expectedMapXRoadMembers, providerKey)
-  if err != nil {
-    t.Errorf("Failed to set test data '%#v'", err)
-  }
-
-  providerRepository := NewProviderRepository(mockClient)
-  actualXRoadMembers, err := providerRepository.GetAll()
-  assert.NoError(t, err)
-
-  assert.Equal(t, expectedXRoadMembers, actualXRoadMembers)
+type MockHTTPClient struct {
+  mock.Mock
 }
 
-func TestProviderRepository_Set(t *testing.T) {
-  mockClient, miniredis := NewRedisMock(t)
-  defer miniredis.Close()
-
-  providerRepository := NewProviderRepository(mockClient)
-  err := providerRepository.Set(expectedXRoadMembers)
-  assert.NoError(t, err)
-
-  actualXRoadMembers, err := getXRoadMembersByMatch(mockClient, providerKey + ":*")
-  if err != nil {
-    t.Errorf("Failed to get actual result '%#v'", err)
-  }
-
-  assert.Equal(t, expectedXRoadMembers, actualXRoadMembers)
+func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+  args := m.Called(req)
+  return args.Get(0).(*http.Response), args.Error(1)
 }
 
-func TestClientRepository_GetAll(t *testing.T) {
-  mockClient, miniredis := NewRedisMock(t)
-  defer miniredis.Close()
+func TestServiceProviderRepository_GetAllServiceProviders(t *testing.T) {
+  mockHTTPClient := new(MockHTTPClient)
 
-  err := hMSetXRoadMembers(mockClient, expectedMapXRoadMembers, clientKey)
-  if err != nil {
-    t.Errorf("Failed to set test data '%#v'", err)
+  responseJson := `{
+  "member": [
+      {
+        "id": {
+          "member_class": "ORG",
+          "member_code": "1111",
+          "object_type": "MEMBER",
+          "xroad_instance": "CS"
+        },
+        "name": "Company 1"
+      },
+      {
+        "id": {
+          "member_class": "ORG",
+          "member_code": "1111",
+          "subsystem_code": "Company1Subsystem",
+          "object_type": "SUBSYSTEM",
+          "xroad_instance": "CS"
+        },
+        "name": "Company 1"
+      }
+    ]
+  }`
+
+  r := ioutil.NopCloser(bytes.NewReader([]byte(responseJson)))
+  response := &http.Response{
+    StatusCode: 200,
+    Body:       r,
   }
 
-  clientRepository := NewClientRepository(mockClient)
-  actualXRoadMembers, err := clientRepository.GetAll()
+  mockHTTPClient.
+    On("Do", mock.Anything).
+    Return(response, nil)
+
+  c := &MetadataServiceClient{HTTPClient: mockHTTPClient}
+
+  spr := NewServiceProviderRepository(c)
+
+  expectedProviders := []*XRoadMember{
+    &XRoadMember{ID: "CS:ORG:1111:Company1Subsystem", Name: "Company 1"},
+  }
+
+  actualProviders, err := spr.GetAllServiceProviders()
   assert.NoError(t, err)
 
-  assert.Equal(t, expectedXRoadMembers, actualXRoadMembers)
+  assert.Equal(t, expectedProviders, actualProviders)
 }
 
-func TestClientRepository_Set(t *testing.T) {
-  mockClient, miniredis := NewRedisMock(t)
-  defer miniredis.Close()
+func TestServiceRepository_GetAllowedServices(t *testing.T) {
+  mockHTTPClient := new(MockHTTPClient)
 
-  clientRepository := NewClientRepository(mockClient)
-  err := clientRepository.Set(expectedXRoadMembers)
-  assert.NoError(t, err)
+  responseJson := `{
+    "service": [
+      {
+        "member_class": "ORG",
+        "member_code": "1111",
+        "object_type": "SERVICE",
+        "service_code": "TestService",
+        "subsystem_code": "Company1Subsystem",
+        "xroad_instance": "CS"
+      }
+    ]
+  }`
 
-  actualXRoadMembers, err := getXRoadMembersByMatch(mockClient, clientKey + ":*")
-  if err != nil {
-    t.Errorf("Failed to get actual result '%#v'", err)
+  r := ioutil.NopCloser(bytes.NewReader([]byte(responseJson)))
+  response := &http.Response{
+    StatusCode: 200,
+    Body:       r,
   }
 
-  assert.Equal(t, expectedXRoadMembers, actualXRoadMembers)
+  mockHTTPClient.
+    On("Do", mock.Anything).
+    Return(response, nil)
+
+  c := &MetadataServiceClient{HTTPClient: mockHTTPClient}
+
+  sr := NewServiceRepository(c)
+
+  expectedServices := []*Service{
+    &Service{ID: "CS:ORG:1111:Company1Subsystem:TestService"},
+  }
+
+  actualServices, err := sr.GetAllowedServices("serviceClientID", new(XRoadMember))
+  assert.NoError(t, err)
+
+  assert.Equal(t, expectedServices, actualServices)
+}
+
+func TestServiceClientRepository_GetServiceClientsByService(t *testing.T) {
+  mockHTTPClient := new(MockHTTPClient)
+
+  responseJson := `[
+    {
+      "id": "CS:ORG:1111:Company1Subsystem",
+      "name": "Company 1",
+      "service_client_type": "SUBSYSTEM",
+      "rights_given_at": "2018-12-15T00:00:00.001Z"
+    }
+  ]`
+
+  r := ioutil.NopCloser(bytes.NewReader([]byte(responseJson)))
+  response := &http.Response{
+    StatusCode: 200,
+    Body:       r,
+  }
+
+  mockHTTPClient.
+    On("Do", mock.Anything).
+    Return(response, nil)
+
+  c := &AdminAPIClient{HTTPClient: mockHTTPClient}
+
+  scs := NewServiceClientRepository(c)
+
+  expectedClients := []*XRoadMember{
+    &XRoadMember{ID: "CS:ORG:1111:Company1Subsystem", Name: "Company 1"},
+  }
+
+  actualClients, err := scs.GetServiceClientsByService("serviceID")
+  assert.NoError(t, err)
+
+  assert.Equal(t, expectedClients, actualClients)
 }

--- a/xroad-metadata-proxy/service_test.go
+++ b/xroad-metadata-proxy/service_test.go
@@ -1,72 +1,98 @@
 package proxy
 
 import (
-  "errors"
   "testing"
 
   "github.com/stretchr/testify/mock"
   "github.com/stretchr/testify/assert"
 )
 
-type MockProviderRepository struct {
+type MockServiceProviderRepository struct {
   mock.Mock
 }
 
-type MockClientRepository struct {
+type MockServiceRepository struct {
   mock.Mock
 }
 
-func (m *MockProviderRepository) GetAll() ([]*XRoadMember, error) {
+type MockServiceClientRepository struct {
+  mock.Mock
+}
+
+func (m *MockServiceProviderRepository) GetAllServiceProviders() ([]*XRoadMember, error) {
   args := m.Called()
   return args.Get(0).([]*XRoadMember), args.Error(1)
 }
 
-func (m *MockProviderRepository) Set([]*XRoadMember) error {
-  return errors.New("Not Implemented")
+func (m *MockServiceRepository) GetAllowedServices(serviceClientID string, serviceProvider *XRoadMember) ([]*Service, error) {
+  args := m.Called(serviceClientID, serviceProvider)
+  return args.Get(0).([]*Service), args.Error(1)
 }
 
-func (m *MockClientRepository) GetAll() ([]*XRoadMember, error) {
-  args := m.Called()
+func (m *MockServiceClientRepository) GetServiceClientsByService(serviceID string) ([]*XRoadMember, error) {
+  args := m.Called(serviceID)
   return args.Get(0).([]*XRoadMember), args.Error(1)
 }
-func (m *MockClientRepository) Set([]*XRoadMember) error {
-  return errors.New("Not Implemented")
-}
 
-func TestProviderService_GetAll(t *testing.T) {
+func TestServiceProviderService_FindServiceProviders(t *testing.T) {
+  allProviders := []*XRoadMember{
+    &XRoadMember{ID: "CS:ORG:1111:Company1Subsystem", Name: "Company 1"},
+    &XRoadMember{ID: "CS:ORG:1112:Company2Subsystem", Name: "Company 2"},
+  }
+
   expectedProviders := []*XRoadMember{
-    &XRoadMember{ID: "CS:ORG:1111:Company1Provider", Name: "Company 1"},
-    &XRoadMember{ID: "CS:ORG:1112:Company2Provider", Name: "Company 2"},
+    &XRoadMember{ID: "CS:ORG:1111:Company1Subsystem", Name: "Company 1"},
   }
 
-  mockProviderRepo := new(MockProviderRepository)
-
-  mockProviderRepo.On("GetAll").Return(expectedProviders, nil)
-
-  providerService := NewProviderService(mockProviderRepo)
-  actualProviders, err := providerService.GetAll()
-  if err != nil {
-    t.Errorf("Failed to call GetAll '%#v'", err)
+  testServices := []*Service{
+    &Service{ID: "CS:ORG:1111:Company1Subsystem:TestService"},
   }
+  otherServices := []*Service{
+    &Service{ID: "CS:ORG:1112:Company2Subsystem:OtherService"},
+  }
+
+  mockspr := new(MockServiceProviderRepository)
+  mocksr := new(MockServiceRepository)
+
+  mockspr.
+    On("GetAllServiceProviders").
+    Return(allProviders, nil)
+
+  provider := &XRoadMember{ID: "CS:ORG:1111:Company1Subsystem", Name: "Company 1"}
+  mocksr.
+    On("GetAllowedServices", mock.Anything, provider).
+    Return(testServices, nil)
+  mocksr.
+    On("GetAllowedServices", mock.Anything, mock.Anything).
+    Return(otherServices, nil)
+
+  serviceClientID := "Anything:Anything:Anything:Anything"
+  serviceCode := "TestService"
+
+  sps := NewServiceProviderService(mockspr, mocksr)
+  actualProviders, err := sps.FindServiceProviders(serviceClientID, serviceCode)
+  assert.NoError(t, err)
 
   assert.Equal(t, expectedProviders, actualProviders)
 }
 
-func TestClientService_GetAll(t *testing.T) {
+func TestServiceClientService_GetServiceClientsByService(t *testing.T) {
   expectedClients := []*XRoadMember{
     &XRoadMember{ID: "CS:ORG:1111:Company1Provider", Name: "Company 1"},
     &XRoadMember{ID: "CS:ORG:1112:Company2Provider", Name: "Company 2"},
   }
 
-  mockClientRepo := new(MockClientRepository)
+  mockscr := new(MockServiceClientRepository)
 
-  mockClientRepo.On("GetAll").Return(expectedClients, nil)
+  serviceID := "CS:ORG:1111:Company1Provider:TestService"
 
-  clientService := NewClientService(mockClientRepo)
-  actualClients, err := clientService.GetAll()
-  if err != nil {
-    t.Errorf("Failed to call GetAll '%#v'", err)
-  }
+  mockscr.
+    On("GetServiceClientsByService", serviceID).
+    Return(expectedClients, nil)
+
+  scs := NewServiceClientService(mockscr)
+  actualClients, err := scs.GetServiceClientsByService(serviceID)
+  assert.NoError(t, err)
 
   assert.Equal(t, expectedClients, actualClients)
 }

--- a/xroad-metadata-proxy/xroad-metadata-proxy.yml
+++ b/xroad-metadata-proxy/xroad-metadata-proxy.yml
@@ -4,3 +4,8 @@
 #
 # database:
 #   addr: localhost:6379
+#
+# securityserver:
+#   url: http://localhost
+#   adminurl: https://localhost:4000/api/v1
+#   apikey: ""


### PR DESCRIPTION
now, xroad-metadata-proxy is working with Security Server metadata service and admin api to get metadata: service clients and service providers.